### PR TITLE
Add responsive menu using slicknav

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 
     
     <div class="mainmenu">
-        <ul>
+        <ul id="nav">
             <li><a href="#">Home</a></li>
             <li><a href="#">About Us</a></li>
             <li><a href="#">Contact Us</a>

--- a/js/main.js
+++ b/js/main.js
@@ -1,62 +1,18 @@
 $(document).ready(function(){
-	/*
-    var n = "#nav", no = "nav-open";
-    $("#nav-menu").click(function(){
-        if($(n).hasClass(no)){
-           // $(n).removeClass(no);
-            $(n).animate({height:0}, 300);
-            
-            setTimeout(function(){
-                $(n).removeClass(no).removeAttr('style');
-            }, 320);
-            
-        }
-        else{
-           // $(n).addClass(no);
-            var newH = $(n).css('height','auto').height();
-            
-            $(n).height(0).animate({height:newH}, 300);
-           
-            setTimeout(function(){
-                $(n).addClass(no).removeAttr('style');
-            }, 320);
-        }
+
+    // Initialize slicknav for responsive menu
+    $('#nav').slicknav({
+        prependTo: '.mainmenu',
+        label: ''
     });
-    */
-    
-    
-    var n = "#nav", no = "nav-open";
-    
-    $(".nav-menu").click(function(){
-        if($(n).hasClass(no)){
-           $(n).animate({height:0},300);
-            
-            setTimeout(function(){
-                 $(n).removeClass(no).removeAttr('style'); 
-            },320)
-        }
-        else{
-            var newH = $(n).css('height','auto').height();
-            $(n).height('0').animate({height:newH}, 300);
-            
-            setTimeout(function(){
-                $(n).addClass(no).removeAttr('style');
-            }, 320)
-           
-            
-        }
-    
-    });
-    
-    
-    
+
     //portfolio
     $('.portfolio').mixItUp({
     animation: {
-		queueLimit: 6
-	}
+                queueLimit: 6
+        }
     });
-    
+
     //fancybox
     $(".fancybox").fancybox({
 		openEffect	: 'none',

--- a/style.css
+++ b/style.css
@@ -46,3 +46,28 @@ a, a:hover{
 
 
 /*End Main Menu*/
+
+/* Responsive Menu */
+.slicknav_menu {
+    display: none;
+}
+
+@media (max-width: 768px) {
+    .mainmenu ul {
+        display: none !important;
+    }
+
+    .slicknav_menu {
+        display: block;
+    }
+}
+
+@media (min-width: 769px) {
+    .mainmenu ul {
+        display: block !important;
+    }
+
+    .slicknav_menu {
+        display: none;
+    }
+}


### PR DESCRIPTION
## Summary
- make main menu responsive with slicknav plugin

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689085b3c5088327870b41c042344635