### PR TITLE
Hide dropdown menus until hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -24,21 +24,21 @@ a, a:hover{
     color: #f9f9f9;
 }
 
-.mainmenu li>ul{
+.mainmenu ul ul{
     position: absolute;
     display: none;
 }
 
-.mainmenu li:hover>ul{
+.mainmenu ul li:hover> ul{
     display: block;
 }
 
-.mainmenu li>ul li{
+.mainmenu ul ul li{
     padding-top: 1px;
     width: 200px;
 }
 
-.mainmenu li>ul li>ul{
+.mainmenu ul ul li> ul{
     left: 100%;
     top:0;
     padding-left: 1px;


### PR DESCRIPTION
## Summary
- ensure nested menu lists stay hidden until their parent is hovered

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68908811570483279d9725ecdf861cfa