### PR TITLE
Enable responsive mobile menu

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,5 @@
 $(document).ready(function(){
+    $('.mainmenu > ul').slicknav();
 	/*
     var n = "#nav", no = "nav-open";
     $("#nav-menu").click(function(){

--- a/style.css
+++ b/style.css
@@ -46,3 +46,18 @@ a, a:hover{
 
 
 /*End Main Menu*/
+
+/* Mobile Menu */
+.slicknav_menu {
+    display: none;
+}
+
+@media screen and (max-width: 768px) {
+    .mainmenu {
+        display: none;
+    }
+    .slicknav_menu {
+        display: block;
+    }
+}
+/* End Mobile Menu */


### PR DESCRIPTION
## Summary
- Initialize SlickNav on the main menu to generate a mobile-friendly toggle.
- Add CSS rules to show the SlickNav menu and hide the original navigation on small screens.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68908aef175c8327b9f75938a021740b